### PR TITLE
Force more html2haml more strict parser so that HAML views are correct

### DIFF
--- a/lib/generators/web_app_theme/theme/theme_generator.rb
+++ b/lib/generators/web_app_theme/theme/theme_generator.rb
@@ -50,7 +50,7 @@ module WebAppTheme
         tmp_html_path = "#{haml_root}/#{admin_layout_name}"
         tmp_haml_path = "#{haml_root}/#{admin_layout_name}.haml"
         template admin_layout_name, tmp_html_path, :verbose => false
-        `html2haml -r #{tmp_html_path} #{tmp_haml_path}`
+        `html2haml --erb --xhtml #{tmp_html_path} #{tmp_haml_path}`
         copy_file tmp_haml_path, "app/views/layouts/#{layout_name.underscore}.html.haml"
       end
     rescue LoadError

--- a/lib/generators/web_app_theme/themed/themed_generator.rb
+++ b/lib/generators/web_app_theme/themed/themed_generator.rb
@@ -113,7 +113,7 @@ module WebAppTheme
           tmp_html_path = "#{haml_root}/#{template_name}"
           tmp_haml_path = "#{haml_root}/#{template_name}.haml"
           template template_name, tmp_html_path, :verbose => false
-          `html2haml -r #{tmp_html_path} #{tmp_haml_path}`
+          `html2haml --erb --xhtml #{tmp_html_path} #{tmp_haml_path}`
           copy_file tmp_haml_path, output_path
         end
       end


### PR DESCRIPTION
The generated "new" and "edit" views when using the themed generator with engine=haml are corrupted.
The line :

<pre>
= render :partial => "form", :locals => {:f => f}
</pre>

that renders the form is not correctly indented and thus is not included in the form block.

The good news is that by using the --xhtml option of the html2haml executable, this line is correctly indented...
