### PR TITLE
Fixed Mongoid ORM support. It was broken.

### DIFF
--- a/lib/generators/web_app_theme/themed/themed_generator.rb
+++ b/lib/generators/web_app_theme/themed/themed_generator.rb
@@ -67,13 +67,17 @@ module WebAppTheme
       resource_name.pluralize
     end
     
-    #If the ORM is mongoid then use the fields on the class to generate the columns
+    ## 
+    # Attempts to call #columns on the model's class
+    # If the (Active Record) #columns method does not exist, it attempts to
+    # perform the (Mongoid) #fields method instead
     def columns
-      excluded_column_names = %w[id created_at updated_at]
-       Kernel.const_get(@model_name).columns.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| Rails::Generators::GeneratedAttribute.new(c.name, c.type)}
-       
-     rescue NoMethodError
-       Kernel.const_get(@model_name).fields.collect{|c| c[1]}.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| Rails::Generators::GeneratedAttribute.new(c.name, c.type.to_s)}
+      begin
+        excluded_column_names = %w[id created_at updated_at]
+        Kernel.const_get(@model_name).columns.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| Rails::Generators::GeneratedAttribute.new(c.name, c.type)} 
+      rescue NoMethodError
+        Kernel.const_get(@model_name).fields.collect{|c| c[1]}.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| Rails::Generators::GeneratedAttribute.new(c.name, c.type.to_s)}
+      end
     end
     
     def extract_modules(name)


### PR DESCRIPTION
Hi.

I tried to use your gem with Mongoid and it appeared to throw an `undefined method` error. So I thought it wasn't supported by **web-app-theme**. But after opening the source of your gem I saw there actually was support for Mongoid, except that the `NoMethodError` exception never gets properly rescued, and this errors out rather than attempting to call the `#fields` method instead. So now it does with this small commit.
