### PR TITLE
Force to display the scrollbar even on pages which are smaller than the viewport height

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -24,6 +24,9 @@ hr {height: 1px; border: 0; }
 p { margin: 15px 0;}
 a img { border: none; }
 
+/* Inspired by http://html5boilerplate.com/docs/#The-style - Always force a scrollbar in non-IE */
+html { overflow-y: scroll; }
+
 body {
   font-size: 12px;
   font-family: sans-serif;  


### PR DESCRIPTION
Inspired by http://html5boilerplate.com/docs/#The-style

IE removes a scrollbar area if, the page is smaller than the viewport height, so when you click into a page which is longer, it appears as though there is a pixel shift but only a scrollbar appears on the right. So, overflow-y: scroll forces it to display the scrollbar even on pages which are smaller than the viewport height.
