### PR TITLE
Support for Formtastic form generation

### DIFF
--- a/app/assets/stylesheets/web-app-theme/base.css
+++ b/app/assets/stylesheets/web-app-theme/base.css
@@ -22,7 +22,8 @@ h3 { font-size: 18px; margin: 10px 0; font-weight: normal;}
 h4 { font-size: 16px; margin: 10px 0; font-weight: normal;}
 hr {height: 1px; border: 0; }
 p { margin: 15px 0;}
-a img { border: none; }
+a img, fieldset { border: none; }
+ol { list-style-type: none; }
 
 body {
   font-size: 12px;

--- a/lib/generators/web_app_theme/themed/templates/view_edit.html.erb
+++ b/lib/generators/web_app_theme/themed/templates/view_edit.html.erb
@@ -9,7 +9,7 @@
   <div class="content">            
     <h2 class="title"><%%= t("web-app-theme.edit", :default => "Edit") %> <%= model_name %></h2>
     <div class="inner">
-      <%%= form_for @<%= model_name.underscore  %>, :url => <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :html => { :class => :form } do |f| -%>
+      <%%= <% if options.formtastic %>semantic_<% end %>form_for @<%= model_name.underscore  %>, :url => <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :html => { :class => 'form' } do |f| -%>
         <%%= render :partial => "form", :locals => {:f => f} %>
       <%% end -%>
     </div>

--- a/lib/generators/web_app_theme/themed/templates/view_form.html.erb
+++ b/lib/generators/web_app_theme/themed/templates/view_form.html.erb
@@ -1,10 +1,21 @@
+<% if options.formtastic %>
+<% unless columns.blank? -%>
+  <%%= f.inputs do %>
+    <% columns.each do |column| %>
+    <%%= f.input :<%= column.name %>, :wrapper_html => { :class => 'group' }, :label_html => { :class => 'label' }, :input_html => { :class => '<%= column.field_type %>' } %>
+    <%- end -%>
+    
+  <%% end -%>
+<%- end -%>
+<%- else -%>
 <% columns.each do |column| %>
   <div class="group">
     <%%= f.label :<%= column.name %>, t("activerecord.attributes.<%= model_name.underscore %>.<%= column.name %>", :default => "<%= column.name.humanize %>"), :class => :label %>
     <%%= f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>' %>
     <span class="description">Ex: a simple text</span>
   </div>
-<%- end -%>        
+<%- end -%>
+<%- end -%>
 <div class="group navform wat-cf">
   <button class="button" type="submit">
     <%%= image_tag("web-app-theme/icons/tick.png", :alt => "#{t("web-app-theme.save", :default => "Save")}") %> <%%= t("web-app-theme.save", :default => "Save") %>

--- a/lib/generators/web_app_theme/themed/templates/view_new.html.erb
+++ b/lib/generators/web_app_theme/themed/templates/view_new.html.erb
@@ -8,7 +8,7 @@
   <div class="content">            
     <h2 class="title"><%%= t("web-app-theme.new", :default => "New")%>  <%= model_name %></h2>
     <div class="inner">
-      <%%= form_for :<%= model_name.underscore  %>, :url => <%= controller_routing_path %>_path, :html => { :class => :form } do |f| -%>
+      <%%= <% if options.formtastic %>semantic_<% end %>form_for :<%= model_name.underscore  %>, :url => <%= controller_routing_path %>_path, :html => { :class => 'form' } do |f| -%>
         <%%= render :partial => "form", :locals => {:f => f} %>
       <%% end -%>
     </div>

--- a/lib/generators/web_app_theme/themed/themed_generator.rb
+++ b/lib/generators/web_app_theme/themed/themed_generator.rb
@@ -11,6 +11,7 @@ module WebAppTheme
     class_option :engine,         :type => :string,   :default => 'erb', :desc => 'Specify the template engine'
     class_option :will_paginate,  :type => :boolean,  :default => false, :desc => 'Specify if you use will_paginate'
     class_option :themed_type,    :type => :string,   :default => 'crud', :desc => 'Specify the themed type, crud or text. Default is crud'
+    class_option :formtastic,     :type => :boolean,  :default => false, :desc => 'Specify if you use formtastic'
     
     def initialize(args, *options)
       super(args, *options)


### PR DESCRIPTION
When generating themed views, you can now pass --formtastic to have the forms generated using the Formtastic format.  

I tweaked `base.css` to remove some generic styles on `<fieldset>`s and `<ol>`s, and then modified the associated template views.  

Calls to `form_for` were replaced with `semantic_form_for`, and all inputs are generated using `f.input` with appropriate label, container, and input classes added.
